### PR TITLE
Support new fields added by nats-server 2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,27 @@ This library also tries to be friendly with `mypy` and `vscode` python extension
 
 ## Installing
 
-At the moment, only installation from source is supported. This can easily be done using `pip`:
+At the moment, only installation from source or wheel is supported. This can easily be done using `pip`:
 
+- Install using `pip` and git repo URL
 
 ```bash
 pip install git+https://github.com/charbonnierg/jetstream.py.git@next
 ```
 
-Or you can add `jetstream.py` as a project dependency using `poetry`:
+- Or you can add `jetstream.py` as a project dependency using `poetry`:
 
 ```bash
 poetry add git+https://github.com/charbonnierg/jetstream.py@next
 ```
 
 > Note: In both cases, you can specify a different branch or tag name in the git URL after the `@` character instead of default `next`
+
+- Or install a release directly from wheel archive:
+
+```bash
+pip install "https://github.com/charbonnierg/jetstream.py/releases/download/v0.1.0/jetstream_python-0.1.0-py3-none-any.whl"
+```
 
 ## Basic usage
 
@@ -56,9 +63,19 @@ async def run():
     # Publish a message that will be routed to the consumer
     await js.publish("test.demo", b"hola")
 
+    # Publish a message and wait for acknowledgement
+    # Returns a PubAck instance: PubAck(stream='TEST', seq=2, domain=None, duplicate=None)
+    ack = await js.stream_publish("test.demo", b"hello")
+    # You can access each field as an attribute
+    assert ack.stream == "TEST"
+
     # Fetch the next message from the consumer and automatically acknowledge it
     msg = await js.consumer_msg_next("TEST", "test-app-01", auto_ack=True)
     assert msg.data == b"hola"
+
+    # Iterate over messages and acknowledge them automatically
+    async for msg in js.consumer_pull_msgs("TEST", "test-app-01", max_msgs=1):
+        print(msg.data)
 ```
 
 ## Example Notebooks

--- a/src/jsm/api/mixins/streams.py
+++ b/src/jsm/api/mixins/streams.py
@@ -23,6 +23,7 @@ from jsm.models.streams import (
     IoNatsJetstreamApiV1StreamUpdateRequest,
     IoNatsJetstreamApiV1StreamUpdateResponse,
     Mirror,
+    PubAck,
     Retention,
     Storage,
 )
@@ -418,3 +419,21 @@ class StreamsMixin(BaseJetStreamRequestReplyMixin):
             raise_on_error=raise_on_error,
             timeout=timeout,
         )
+
+    async def stream_publish(
+        self,
+        subject: str,
+        /,
+        payload: bytes,
+        timeout: Optional[float] = None,
+    ) -> PubAck:
+        """Publish a message to an NATS subject and wait for stream acknowledgement.
+
+        Args:
+            * `subject`: subject to publish message to
+            * `payload`: content of the message in bytes
+            * `timeout`: optional timeout in seconds
+        """
+        options = {"timeout": timeout} if timeout else {}
+        res = await self.request(subject, payload, **options)  # type: ignore[attr-defined]
+        return PubAck.parse_raw(res.data)

--- a/src/jsm/api/subscription.py
+++ b/src/jsm/api/subscription.py
@@ -39,7 +39,7 @@ class Msg:
         if not self._client:
             raise NatsError("client not set")
 
-        await self._client.publish(self.reply, data, headers=self.headers)
+        await self._client.publish(self.reply, data)
 
     async def ack(self) -> None:
         """Acknowledge a JetStream message"""

--- a/src/jsm/models/consumers.py
+++ b/src/jsm/models/consumers.py
@@ -69,6 +69,10 @@ class Config(JetstreamModel):
         "last",
         description="Specify where in the stream the consumer should start receiving messages",
     )
+    deliver_group: Optional[str] = Field(
+        None,
+        description="specify which deliver group (or queue group name) the consumer is created for",
+    )
     ack_policy: AckPolicy = Field(
         "explicit",
         description="How messages should be acknowledged",
@@ -150,6 +154,10 @@ class Delivered(JetstreamModel):
         description="The sequence number of the Stream",
         ge=0,
     )
+    last: Optional[datetime] = Field(
+        None,
+        description="A timestamp that shows when last message was delivered",
+    )
 
 
 class AckFloor(JetstreamModel):
@@ -167,6 +175,9 @@ class AckFloor(JetstreamModel):
         ...,
         description="The sequence number of the Stream",
         ge=0,
+    )
+    last: Optional[datetime] = Field(
+        None, description="A timestamp that shows when last message was ACKed"
     )
 
 
@@ -218,6 +229,10 @@ class IoNatsJetstreamApiV1ConsumerItem(JetstreamModel):
         ge=0,
     )
     cluster: Optional[Cluster] = None
+    push_bound: Optional[bool] = Field(
+        None,
+        description="Indicates if any client is connected and receiving messages from a push consumer",
+    )
 
 
 class IoNatsJetstreamApiV1ConsumerCreateResponse(

--- a/src/jsm/models/streams.py
+++ b/src/jsm/models/streams.py
@@ -269,6 +269,15 @@ class State(JetstreamModel):
     )
 
 
+class PubAck(JetstreamModel):
+    stream: str = Field(..., description="Name of the stream")
+    seq: int = Field(..., description="Sequence of the message in the steam")
+    domain: Optional[str] = Field(
+        None, description="JetStream domain which acknowledged the message"
+    )
+    duplicate: Optional[bool] = None
+
+
 class IoNatsJetstreamApiV1StreamItem(JetstreamModel):
     config: Config = Field(
         ...,


### PR DESCRIPTION
This PR implements changes described in <https://github.com/nats-io/nats-architecture-and-design/issues/43>

It also add a new method to the client `stream_publish`. It is a simple wrapper around the `request` method that can be used to publish a message and wait for a stream acknowledgement. It returns a `PubAck`, optionally with the new field `domain` set to the JetStream domain which ACKed the message